### PR TITLE
Prioritize methods from interfaces when a class is generated

### DIFF
--- a/src/main/java/org/jboss/invocation/proxy/ProxyFactory.java
+++ b/src/main/java/org/jboss/invocation/proxy/ProxyFactory.java
@@ -281,10 +281,10 @@ public class ProxyFactory<T> extends AbstractProxyFactory<T> {
             createWriteReplace();
         }
         MethodBodyCreator creator = getDefaultMethodOverride();
-        overrideAllMethods(creator);
         for (Class<?> iface : additionalInterfaces) {
             addInterface(creator, iface);
         }
+        overrideAllMethods(creator);
         overrideEquals(creator);
         overrideHashcode(creator);
         overrideToString(creator);


### PR DESCRIPTION
This a hacky fix to a problem in https://issues.redhat.com/browse/EAPSUP-564: we need to add superclass to a proxy to preserve validation data, but when we do the EJB code (which hashes methods based on interface methods) starts to fail because the methods from the bean superclass are prioritized. After this fix this is reversed.