### PR TITLE
Avoid override final methods in proxy superclass when generating proxy

### DIFF
--- a/src/main/java/org/jboss/invocation/proxy/AbstractSubclassFactory.java
+++ b/src/main/java/org/jboss/invocation/proxy/AbstractSubclassFactory.java
@@ -18,13 +18,6 @@
 
 package org.jboss.invocation.proxy;
 
-import org.jboss.classfilewriter.AccessFlag;
-import org.jboss.classfilewriter.ClassFactory;
-import org.jboss.classfilewriter.ClassMethod;
-import org.jboss.classfilewriter.util.DescriptorUtils;
-import org.jboss.invocation.proxy.reflection.ClassMetadataSource;
-import org.jboss.invocation.proxy.reflection.ReflectionMetadataSource;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -34,6 +27,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+
+import org.jboss.classfilewriter.AccessFlag;
+import org.jboss.classfilewriter.ClassFactory;
+import org.jboss.classfilewriter.ClassMethod;
+import org.jboss.classfilewriter.util.DescriptorUtils;
+import org.jboss.invocation.proxy.reflection.ClassMetadataSource;
+import org.jboss.invocation.proxy.reflection.ReflectionMetadataSource;
 
 /**
  * Class factory for classes that override superclass methods.
@@ -175,6 +175,13 @@ public abstract class AbstractSubclassFactory<T> extends AbstractClassFactory<T>
         MethodIdentifier identifier;
         while (currentClass != null && currentClass != Object.class) {
             data = reflectionMetadataSource.getClassMetadata(currentClass);
+
+            // first pass to exclude any final methods and their overridden methods in superclass
+            for (Method method : data.getDeclaredMethods()) {
+                if (Modifier.isFinal(method.getModifiers()) && method.getDeclaringClass() != Object.class) {
+                    overriddenMethods.add(MethodIdentifier.getIdentifierForMethod(method));
+                }
+            }
             for (Method method : data.getDeclaredMethods()) {
                 if (!Modifier.isPublic(method.getModifiers())) {
                     continue; // don't override non public methods
@@ -224,6 +231,13 @@ public abstract class AbstractSubclassFactory<T> extends AbstractClassFactory<T>
         MethodIdentifier identifier;
         while (currentClass != null && currentClass != Object.class) {
             data = reflectionMetadataSource.getClassMetadata(currentClass);
+
+            // first pass to exclude any final methods and their overridden methods in superclass
+            for (Method method : data.getDeclaredMethods()) {
+                if (Modifier.isFinal(method.getModifiers()) && method.getDeclaringClass() != Object.class) {
+                    overriddenMethods.add(MethodIdentifier.getIdentifierForMethod(method));
+                }
+            }
             for (Method method : data.getDeclaredMethods()) {
                 if (Modifier.isStatic(method.getModifiers())) {
                     continue; // don't override static methods

--- a/src/test/java/org/jboss/invocation/proxy/test/proxyfactory/SimpleClass2.java
+++ b/src/test/java/org/jboss/invocation/proxy/test/proxyfactory/SimpleClass2.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2016 Red Hat, Inc., and individual contributors
+ * Copyright 2021 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.jboss.invocation.proxy.test.proxyfactory;
 
+public class SimpleClass2 extends SimpleClass {
 
-public class SimpleClass {
-
-    public SimpleClass() {
-
+    /**
+     * This is a final method that overrides {@code foo} method from its superclass.
+     * Generated proxy class should not override this method.
+     */
+    @Override
+    public final void foo() {
     }
 
-    public Object[] method1() {
-        return null;
-    }
-
-    public Object[] method2(long v1, double v2, Object v3, int[] v4) {
-        return null;
-    }
-
-    public void foo() {
-        throw new UnsupportedOperationException();
-    }
-
-    protected void bar() {
-        throw new UnsupportedOperationException();
+    /**
+     * This is a final method that overrides {@code bar} method from its superclass.
+     * Generated proxy class should not override this method.
+     */
+    @Override
+    protected final void bar() {
     }
 }

--- a/src/test/java/org/jboss/invocation/proxy/test/proxyfactory/SimpleProxyFactoryTest.java
+++ b/src/test/java/org/jboss/invocation/proxy/test/proxyfactory/SimpleProxyFactoryTest.java
@@ -17,13 +17,13 @@
  */
 package org.jboss.invocation.proxy.test.proxyfactory;
 
+import java.lang.reflect.Method;
+import java.util.List;
+
 import junit.framework.Assert;
 import org.jboss.invocation.proxy.ProxyConfiguration;
 import org.jboss.invocation.proxy.ProxyFactory;
 import org.junit.Test;
-
-import java.lang.reflect.Method;
-import java.util.List;
 
 public class SimpleProxyFactoryTest {
 
@@ -41,6 +41,20 @@ public class SimpleProxyFactoryTest {
         Assert.assertEquals(10L, array[0]);
         Assert.assertEquals(0.0, array[1]);
 
+    }
+
+    /**
+     * The final methods in {@code SimpleClass2} should not be overridden in the generated proxy class.
+     */
+    @Test
+    public void testSimpleProxy2() throws InstantiationException, IllegalAccessException {
+        final ProxyConfiguration<SimpleClass2> proxyConfiguration = new ProxyConfiguration<SimpleClass2>()
+                .setSuperClass(SimpleClass2.class)
+                .setProxyName(SimpleClass2.class.getPackage(), "SimpleClass2$$Proxy3")
+                .setClassLoader(SimpleClass2.class.getClassLoader());
+        ProxyFactory<SimpleClass2> proxyFactory = new ProxyFactory<SimpleClass2>(proxyConfiguration);
+        SimpleClass2 instance = proxyFactory.newInstance(new SimpleInvocationHandler());
+        instance.method1();
     }
 
     @Test
@@ -68,7 +82,7 @@ public class SimpleProxyFactoryTest {
                 .setClassLoader(SimpleClass.class.getClassLoader());
         ProxyFactory<SimpleClass> proxyFactory = new ProxyFactory<SimpleClass>(proxyConfiguration);
         List<Method> methods = proxyFactory.getCachedMethods();
-        Assert.assertEquals(5, methods.size());
+        Assert.assertEquals(7, methods.size());
         Method method1 = null;
         for (Method m : methods) {
             if (m.getName().equals("method1")) {


### PR DESCRIPTION
When ProxyFactory generates proxy, it traverses up the inheritance chain. A method can be declared non-final in a superclass, but as final in a subclass. When ProxyFactory first encounters this method in subclass, it sees it as final and skips it; but as it later sees the same method in superclass which is not a final method, the ProxyFactory overrides this method in the generated proxy class, which makes the proxy invalid.