### PR TITLE
Replaced getParameterTypes().length with getParameterCount()

### DIFF
--- a/javax/src/main/java/org/jboss/invocation/MethodInterceptor.java
+++ b/javax/src/main/java/org/jboss/invocation/MethodInterceptor.java
@@ -56,7 +56,7 @@ public final class MethodInterceptor implements Interceptor {
         this.method = method;
         this.interceptorInstance = interceptorInstance;
         checkMethodType(interceptorInstance);
-        withContext = method.getParameterTypes().length == 1;
+        withContext = method.getParameterCount() == 1;
     }
 
     /**


### PR DESCRIPTION
getParameterTypes().length is inefficient because it creates an array clone, while getParameterCount() directly returns the length.

https://issues.redhat.com/browse/WFLY-15612